### PR TITLE
Make road type choices exclusionary

### DIFF
--- a/WME ClickSaver.js
+++ b/WME ClickSaver.js
@@ -65,6 +65,7 @@
                 dropdownHelperGroup: 'DROPDOWN HELPERS',
                 roadTypeButtons: 'Add road type buttons',
                 useOldRoadColors: 'Use old road colors (requires refresh)',
+                setCityToDefault: 'Keep default value',
                 setStreetCityToNone: 'Set Street/City to None (new seg\'s only)',
                 // eslint-disable-next-line camelcase
                 setStreetCityToNone_Title: 'NOTE: Only works if connected directly or indirectly'
@@ -86,6 +87,12 @@
             // eslint-disable-next-line camelcase
             swapSegmentTypeError_Paths: 'Paths must be removed from segment before changing between driving and pedestrian road type.',
             addAltCityButtonText: 'Add alt city'
+        };
+
+        const roadTypeDropdownOption = {
+            DEFAULT: 'DEFAULT',
+            NONE: 'NONE',
+            CONNECTED_CITY: 'CONNECTED_CITY'
         };
 
         // Road types defined in the WME SDK documentation
@@ -168,34 +175,30 @@
                 roadTypeButtons: ['St', 'PS', 'mH', 'MH', 'Fw', 'Rmp', 'PLR', 'PR', 'PB'],
                 parkingCostButtons: true,
                 parkingSpacesButtons: true,
-                setNewPLRStreetToNone: true,
-                setNewPLRCity: true,
-                setNewPRStreetToNone: false,
-                setNewPRCity: false,
-                setNewRRStreetToNone: true, // added by jm6087
-                setNewRRCity: false, // added by jm6087
-                setNewPBStreetToNone: true, // added by jm6087
-                setNewPBCity: true, // added by jm6087
-                setNewORStreetToNone: false,
-                setNewORCity: false,
+                setNewPLRCity: roadTypeDropdownOption.DEFAULT,
+                setNewPRCity: roadTypeDropdownOption.DEFAULT,
+                setNewRRCity: roadTypeDropdownOption.DEFAULT,
+                setNewPBCity: roadTypeDropdownOption.DEFAULT,
+                setNewORCity: roadTypeDropdownOption.DEFAULT,
                 addAltCityButton: true,
                 addSwapPedestrianButton: false,
                 useOldRoadColors: false,
                 warnOnPedestrianTypeSwap: true,
                 addCompactColors: true,
                 addSwitchPrimaryNameButton: false,
+                hideUncheckedRoadTypeButtons: false,
                 shortcuts: {}
             };
             _settings = { ...defaultSettings, ...loadedSettings };
 
             setChecked('csRoadTypeButtonsCheckBox', _settings.roadButtons);
             if (_settings.roadTypeButtons) {
-                Object.keys(roadTypeSettings).forEach(roadTypeAbbr1 => {
-                    const checked = _settings.roadTypeButtons.indexOf(roadTypeAbbr1) !== -1;
-                    const selector = `cs${roadTypeAbbr1}CheckBox`
+                Object.keys(roadTypeSettings).forEach(roadTypeAbbr => {
+                    const checked = _settings.roadTypeButtons.indexOf(roadTypeAbbr) !== -1;
+                    const selector = `cs${roadTypeAbbr}CheckBox`;
                     setChecked(selector, checked);
                     if (!checked) {
-                        $(`#${selector}`).siblings('.csRadioButtonContainer').hide();
+                        $(`#${selector}`).siblings('.csDropdownContainer').hide();
                     }
                 });
             }
@@ -207,22 +210,21 @@
             }
             // setChecked('csParkingSpacesButtonsCheckBox', _settings.parkingSpacesButtons);
             // setChecked('csParkingCostButtonsCheckBox', _settings.parkingCostButtons);
-            setChecked('csClearNewPLRRadioButton', _settings.setNewPLRStreetToNone);
-            setChecked('csSetNewPLRCityRadioButton', _settings.setNewPLRCity);
-            setChecked('csClearNewPRRadioButton', _settings.setNewPRStreetToNone);
-            setChecked('csSetNewPRCityRadioButton', _settings.setNewPRCity);
-            setChecked('csClearNewRRRadioButton', _settings.setNewRRStreetToNone); // added by jm6087
-            setChecked('csSetNewRRCityRadioButton', _settings.setNewRRCity);
-            setChecked('csClearNewPBRadioButton', _settings.setNewPBStreetToNone); // added by jm6087
-            setChecked('csSetNewPBCityRadioButton', _settings.setNewPBCity);
-            setChecked('csClearNewORRadioButton', _settings.setNewORStreetToNone);
-            setChecked('csSetNewORCityRadioButton', _settings.setNewORCity);
+            setDropdownValue('csSetPLRCityDropdown', _settings.setNewPLRCity);
+            setDropdownValue('csSetPRCityDropdown', _settings.setNewPRCity);
+            setDropdownValue('csSetRRCityDropdown', _settings.setNewRRCity);
+            setDropdownValue('csSetPBCityDropdown', _settings.setNewPBCity);
+            setDropdownValue('csSetORCityDropdown', _settings.setNewORCity);
             setChecked('csUseOldRoadColorsCheckBox', _settings.useOldRoadColors);
             setChecked('csAddAltCityButtonCheckBox', _settings.addAltCityButton);
             setChecked('csAddSwapPedestrianButtonCheckBox', _settings.addSwapPedestrianButton);
             setChecked('csAddCompactColorsCheckBox', _settings.addCompactColors);
             setChecked('csAddSwitchPrimaryNameCheckBox', _settings.addSwitchPrimaryNameButton);
             setChecked('csHideUncheckedRoadTypeButtonsCheckBox', _settings.hideUncheckedRoadTypeButtons);
+        }
+
+        function setDropdownValue(dropdownId, value) {
+            $(`#${dropdownId}`).val(value);
         }
 
         function saveSettingsToStorage() {
@@ -232,15 +234,10 @@
                 parkingCostButtons: _settings.parkingCostButtons,
                 parkingSpacesButtons: _settings.parkingSpacesButtons,
                 setNewPLRCity: _settings.setNewPLRCity,
-                setNewPLRStreetToNone: _settings.setNewPLRStreetToNone,
                 setNewPRCity: _settings.setNewPRCity,
-                setNewPRStreetToNone: _settings.setNewPRStreetToNone,
                 setNewRRCity: _settings.setNewRRCity,
-                setNewRRStreetToNone: _settings.setNewRRStreetToNone,
                 setNewPBCity: _settings.setNewPBCity,
-                setNewPBStreetToNone: _settings.setNewPBStreetToNone,
                 setNewORCity: _settings.setNewORCity,
-                setNewORStreetToNone: _settings.setNewORStreetToNone,
                 useOldRoadColors: _settings.useOldRoadColors,
                 addAltCityButton: _settings.addAltCityButton,
                 addSwapPedestrianButton: _settings.addSwapPedestrianButton,
@@ -402,17 +399,19 @@
                 }
             });
 
-            if (roadType === roadTypeSettings.PLR.id) {
-                setStreetAndCity(isChecked('csSetNewPLRCityRadioButton'));
-            } else if (roadType === roadTypeSettings.PR.id) {
-                setStreetAndCity(isChecked('csSetNewPRCityRadioButton'));
-            } else if (roadType === roadTypeSettings.RR.id) {
-                setStreetAndCity(isChecked('csSetNewRRCityRadioButton'));
-            } else if (roadType === roadTypeSettings.PB) {
-                setStreetAndCity(isChecked('csSetNewPBCityRadioButton'));
-            } else if (roadType === roadTypeSettings.OR.id) {
-                setStreetAndCity(isChecked('csSetNewORCityRadioButton'));
+            const roadTypeSettingsMap = {
+                [roadTypeSettings.PLR.id]: _settings.setNewPLRCity,
+                [roadTypeSettings.PR.id]: _settings.setNewPRCity,
+                [roadTypeSettings.RR.id]: _settings.setNewRRCity,
+                [roadTypeSettings.PB.id]: _settings.setNewPBCity,
+                [roadTypeSettings.OR.id]: _settings.setNewORCity,
+            };
+            const setting = roadTypeSettingsMap[roadType];
+
+            if (!setting || setting === roadTypeDropdownOption.DEFAULT) {
+                return;
             }
+            setStreetAndCity(setting === roadTypeDropdownOption.CONNECTED_CITY);
             // });
         }
 
@@ -849,20 +848,34 @@
             $(`<style type="text/css">${css}</style>`).appendTo('head');
         }
 
+        function createSettingsDropdown(id, settingName, titleText, divCss, options, optionalAttributes) {
+            const $container = $('<div>', { class: 'controls-container' });
+            const $select = $('<select>', {
+                class: 'csSettingsControl',
+                id,
+                'data-setting-name': settingName
+            }).appendTo($container);
+            // TODO css
+            if (divCss) $container.css(divCss);
+            // TODO css
+            if (titleText) $container.attr({ title: titleText });
+            if (optionalAttributes) $select.attr(optionalAttributes);
+            options.forEach(option => {
+                $select.append($('<option>', {
+                    value: option.value,
+                    text: option.text
+                }));
+            });
+
+            return $container;
+        }
+
         function createSettingsCheckbox(id, settingName, labelText, titleText, divCss, labelCss, optionalAttributes) {
-            return createSettingsInput('checkbox', id, settingName, labelText, titleText, divCss, labelCss, null, optionalAttributes);
-        }
-
-        function createSettingsRadioButton(id, settingName, labelText, titleText, divCss, labelCss, groupName, optionalAttributes) {
-            return createSettingsInput('radio', id, settingName, labelText, titleText, divCss, labelCss, groupName, optionalAttributes);
-        }
-
-        function createSettingsInput(type, id, settingName, labelText, titleText, divCss, labelCss, groupName, optionalAttributes) {
             const $container = $('<div>', { class: 'controls-container' });
             const $input = $('<input>', {
-                type: type,
+                type: 'checkbox',
                 class: 'csSettingsControl',
-                name: type === 'radio' ? groupName : id,
+                name: id,
                 id,
                 'data-setting-name': settingName
             }).appendTo($container);
@@ -890,29 +903,23 @@
                 });
                 $roadTypesDiv.append($roadTypeContainer);
                 if (['PLR', 'PR', 'RR', 'PB', 'OR'].includes(roadTypeAbbr)) { // added RR & PB by jm6087
-                    const $radioButtonContainer = $('<div>', { class: 'csRadioButtonContainer' });
-                    $radioButtonContainer.append(
+                    const $dropdownContainer = $('<div>', { class: 'csDropdownContainer' });
+                    const options = [
+                        { value: roadTypeDropdownOption.DEFAULT, text: trans.prefs.setCityToDefault },
+                        { value: roadTypeDropdownOption.NONE, text: trans.prefs.setStreetCityToNone },
+                        { value: roadTypeDropdownOption.CONNECTED_CITY, text: trans.prefs.setCityToConnectedSegCity }
+                    ];
+                    $dropdownContainer.append(
                         // TODO css
-                        createSettingsRadioButton(
-                            `csClearNew${roadTypeAbbr}RadioButton`,
-                            `setNew${roadTypeAbbr}StreetToNone`,
-                            trans.prefs.setStreetCityToNone,
-                            trans.prefs.setStreetCityToNone_Title,
-                            { paddingLeft: '20px', marginRight: '4px' },
-                            { fontStyle: 'italic' },
-                            `cs${roadTypeAbbr}SettingGroup`
-                        ),
-                        createSettingsRadioButton(
-                            `csSetNew${roadTypeAbbr}CityRadioButton`,
+                        createSettingsDropdown(
+                            `csSet${roadTypeAbbr}CityDropdown`,
                             `setNew${roadTypeAbbr}City`,
-                            trans.prefs.setCityToConnectedSegCity,
                             '',
                             { paddingLeft: '20px', marginRight: '4px' },
-                            { fontStyle: 'italic' },
-                            `cs${roadTypeAbbr}SettingGroup`
+                            options
                         )
                     );
-                    $roadTypeContainer.append($radioButtonContainer);
+                    $roadTypeContainer.append($dropdownContainer);
                 }
             });
 
@@ -989,16 +996,12 @@
             });
             $('.csSettingsControl').change(function onSettingsCheckChanged() {
                 const { checked } = this;
-                const settingName = $(this).data('setting-name');
-
-                if (!checked) {
-                    $(this).siblings('.csRadioButtonContainer').hide();
-                } else {
-                    $(this).siblings('.csRadioButtonContainer').show();
-                }
+                const $this = $(this);
+                const settingName = $this.data('setting-name');
+                $this.siblings('.csDropdownContainer').toggle(checked);
 
                 if (settingName === 'roadType') {
-                    const roadType = $(this).data('road-type');
+                    const roadType = $this.data('road-type');
                     const array = _settings.roadTypeButtons;
                     const index = array.indexOf(roadType);
                     if (checked && index === -1) {
@@ -1007,15 +1010,8 @@
                         array.splice(index, 1);
                     }
                 } else {
-                    const roadTypeAbbr = $(this).parent().parent().siblings().attr('data-road-type');
-                    if (settingName.includes('setNew')) {
-                        _settings[settingName] = checked;
-
-                        if (settingName.endsWith('StreetToNone')) {
-                            _settings[`setNew${roadTypeAbbr}City`] = !checked;
-                        } else {
-                            _settings[`setNew${roadTypeAbbr}StreetToNone`] = !checked;
-                        }
+                    if (settingName.includes('setNew') && settingName.includes('City')) {
+                        _settings[settingName] = $this.val();
                     } else {
                         _settings[settingName] = checked;
                     }

--- a/WME ClickSaver.js
+++ b/WME ClickSaver.js
@@ -855,7 +855,7 @@
                 class: 'csSettingsControl',
                 id,
                 // TODO css
-                style: 'font-size: 12px; border-color: #cbcbcb;border-radius: 10px',
+                style: 'font-size: 12px; border-color: #cbcbcb;border-radius: 10px; white-space: nowrap; width: 100%; text-overflow: ellipsis;',
                 'data-setting-name': settingName
             }).appendTo($container);
             // TODO css

--- a/WME ClickSaver.js
+++ b/WME ClickSaver.js
@@ -399,20 +399,21 @@
                 }
             });
 
-            const roadTypeSettingsMap = {
-                [roadTypeSettings.PLR.id]: _settings.setNewPLRCity,
-                [roadTypeSettings.PR.id]: _settings.setNewPRCity,
-                [roadTypeSettings.RR.id]: _settings.setNewRRCity,
-                [roadTypeSettings.PB.id]: _settings.setNewPBCity,
-                [roadTypeSettings.OR.id]: _settings.setNewORCity,
-            };
-            const setting = roadTypeSettingsMap[roadType];
+            if (_settings.roadTypeButtons.map(rtb => roadTypeSettings[rtb].id).includes(roadType)) {
+                const roadTypeSettingsMap = {
+                    [roadTypeSettings.PLR.id]: _settings.setNewPLRCity,
+                    [roadTypeSettings.PR.id]: _settings.setNewPRCity,
+                    [roadTypeSettings.RR.id]: _settings.setNewRRCity,
+                    [roadTypeSettings.PB.id]: _settings.setNewPBCity,
+                    [roadTypeSettings.OR.id]: _settings.setNewORCity
+                };
+                const setting = roadTypeSettingsMap[roadType];
 
-            if (!setting || setting === roadTypeDropdownOption.DEFAULT) {
-                return;
+                if (!setting || setting === roadTypeDropdownOption.DEFAULT) {
+                    return;
+                }
+                setStreetAndCity(setting === roadTypeDropdownOption.CONNECTED_CITY);
             }
-            setStreetAndCity(setting === roadTypeDropdownOption.CONNECTED_CITY);
-            // });
         }
 
         function addRoadTypeButtons() {
@@ -853,6 +854,8 @@
             const $select = $('<select>', {
                 class: 'csSettingsControl',
                 id,
+                // TODO css
+                style: 'font-size: 12px; border-color: #cbcbcb;border-radius: 10px',
                 'data-setting-name': settingName
             }).appendTo($container);
             // TODO css
@@ -1009,12 +1012,10 @@
                     } else if (!checked && index !== -1) {
                         array.splice(index, 1);
                     }
+                } else if (settingName.includes('setNew') && settingName.includes('City')) {
+                    _settings[settingName] = $this.val();
                 } else {
-                    if (settingName.includes('setNew') && settingName.includes('City')) {
-                        _settings[settingName] = $this.val();
-                    } else {
-                        _settings[settingName] = checked;
-                    }
+                    _settings[settingName] = checked;
                 }
                 saveSettingsToStorage();
             });

--- a/WME ClickSaver.js
+++ b/WME ClickSaver.js
@@ -191,7 +191,12 @@
             setChecked('csRoadTypeButtonsCheckBox', _settings.roadButtons);
             if (_settings.roadTypeButtons) {
                 Object.keys(roadTypeSettings).forEach(roadTypeAbbr1 => {
-                    setChecked(`cs${roadTypeAbbr1}CheckBox`, _settings.roadTypeButtons.indexOf(roadTypeAbbr1) !== -1);
+                    const checked = _settings.roadTypeButtons.indexOf(roadTypeAbbr1) !== -1;
+                    const selector = `cs${roadTypeAbbr1}CheckBox`
+                    setChecked(selector, checked);
+                    if (!checked) {
+                        $(`#${selector}`).siblings('.csRadioButtonContainer').hide();
+                    }
                 });
             }
 
@@ -202,16 +207,16 @@
             }
             // setChecked('csParkingSpacesButtonsCheckBox', _settings.parkingSpacesButtons);
             // setChecked('csParkingCostButtonsCheckBox', _settings.parkingCostButtons);
-            setChecked('csSetNewPLRCityCheckBox', _settings.setNewPLRCity);
-            setChecked('csClearNewPLRCheckBox', _settings.setNewPLRStreetToNone);
-            setChecked('csSetNewPRCityCheckBox', _settings.setNewPRCity);
-            setChecked('csClearNewPRCheckBox', _settings.setNewPRStreetToNone);
-            setChecked('csSetNewRRCityCheckBox', _settings.setNewRRCity);
-            setChecked('csClearNewRRCheckBox', _settings.setNewRRStreetToNone); // added by jm6087
-            setChecked('csSetNewPBCityCheckBox', _settings.setNewPBCity);
-            setChecked('csClearNewPBCheckBox', _settings.setNewPBStreetToNone); // added by jm6087
-            setChecked('csSetNewORCityCheckBox', _settings.setNewORCity);
-            setChecked('csClearNewORCheckBox', _settings.setNewORStreetToNone);
+            setChecked('csClearNewPLRRadioButton', _settings.setNewPLRStreetToNone);
+            setChecked('csSetNewPLRCityRadioButton', _settings.setNewPLRCity);
+            setChecked('csClearNewPRRadioButton', _settings.setNewPRStreetToNone);
+            setChecked('csSetNewPRCityRadioButton', _settings.setNewPRCity);
+            setChecked('csClearNewRRRadioButton', _settings.setNewRRStreetToNone); // added by jm6087
+            setChecked('csSetNewRRCityRadioButton', _settings.setNewRRCity);
+            setChecked('csClearNewPBRadioButton', _settings.setNewPBStreetToNone); // added by jm6087
+            setChecked('csSetNewPBCityRadioButton', _settings.setNewPBCity);
+            setChecked('csClearNewORRadioButton', _settings.setNewORStreetToNone);
+            setChecked('csSetNewORCityRadioButton', _settings.setNewORCity);
             setChecked('csUseOldRoadColorsCheckBox', _settings.useOldRoadColors);
             setChecked('csAddAltCityButtonCheckBox', _settings.addAltCityButton);
             setChecked('csAddSwapPedestrianButtonCheckBox', _settings.addSwapPedestrianButton);
@@ -307,7 +312,7 @@
                         };
                         let newCityId = sdk.DataModel.Cities.getCity(newCityProperties)?.id;
                         if (newCityId == null) {
-                            newCityId = sdk.DataModel.Cities.addCity(newCityProperties);
+                            newCityId = sdk.DataModel.Cities.addCity(newCityProperties).id;
                         }
 
                         // Process the street
@@ -397,16 +402,16 @@
                 }
             });
 
-            if (roadType === roadTypeSettings.PLR.id && isChecked('csClearNewPLRCheckBox')) {
-                setStreetAndCity(isChecked('csSetNewPLRCityCheckBox'));
-            } else if (roadType === roadTypeSettings.PR.id && isChecked('csClearNewPRCheckBox')) {
-                setStreetAndCity(isChecked('csSetNewPRCityCheckBox'));
-            } else if (roadType === roadTypeSettings.RR.id && isChecked('csClearNewRRCheckBox')) {
-                setStreetAndCity(isChecked('csSetNewRRCityCheckBox'));
-            } else if (roadType === roadTypeSettings.PB && isChecked('csClearNewPBCheckBox')) {
-                setStreetAndCity(isChecked('csSetNewPBCityCheckBox'));
-            } else if (roadType === roadTypeSettings.OR.id && isChecked('csClearNewORCheckBox')) {
-                setStreetAndCity(isChecked('csSetNewORCityCheckBox'));
+            if (roadType === roadTypeSettings.PLR.id) {
+                setStreetAndCity(isChecked('csSetNewPLRCityRadioButton'));
+            } else if (roadType === roadTypeSettings.PR.id) {
+                setStreetAndCity(isChecked('csSetNewPRCityRadioButton'));
+            } else if (roadType === roadTypeSettings.RR.id) {
+                setStreetAndCity(isChecked('csSetNewRRCityRadioButton'));
+            } else if (roadType === roadTypeSettings.PB) {
+                setStreetAndCity(isChecked('csSetNewPBCityRadioButton'));
+            } else if (roadType === roadTypeSettings.OR.id) {
+                setStreetAndCity(isChecked('csSetNewORCityRadioButton'));
             }
             // });
         }
@@ -845,9 +850,21 @@
         }
 
         function createSettingsCheckbox(id, settingName, labelText, titleText, divCss, labelCss, optionalAttributes) {
+            return createSettingsInput('checkbox', id, settingName, labelText, titleText, divCss, labelCss, null, optionalAttributes);
+        }
+
+        function createSettingsRadioButton(id, settingName, labelText, titleText, divCss, labelCss, groupName, optionalAttributes) {
+            return createSettingsInput('radio', id, settingName, labelText, titleText, divCss, labelCss, groupName, optionalAttributes);
+        }
+
+        function createSettingsInput(type, id, settingName, labelText, titleText, divCss, labelCss, groupName, optionalAttributes) {
             const $container = $('<div>', { class: 'controls-container' });
             const $input = $('<input>', {
-                type: 'checkbox', class: 'csSettingsCheckBox', name: id, id, 'data-setting-name': settingName
+                type: type,
+                class: 'csSettingsControl',
+                name: type === 'radio' ? groupName : id,
+                id,
+                'data-setting-name': settingName
             }).appendTo($container);
             const $label = $('<label>', { for: id }).text(labelText).appendTo($container);
             // TODO css
@@ -868,31 +885,34 @@
                 const roadType = roadTypeSettings[roadTypeAbbr];
                 const id = `cs${roadTypeAbbr}CheckBox`;
                 const title = I18n.t('segment.road_types')[roadType.id];
-                $roadTypesDiv.append(
-                    createSettingsCheckbox(id, 'roadType', title, null, null, null, {
-                        'data-road-type': roadTypeAbbr
-                    })
-                );
+                const $roadTypeContainer = createSettingsCheckbox(id, 'roadType', title, null, null, null, {
+                    'data-road-type': roadTypeAbbr
+                });
+                $roadTypesDiv.append($roadTypeContainer);
                 if (['PLR', 'PR', 'RR', 'PB', 'OR'].includes(roadTypeAbbr)) { // added RR & PB by jm6087
-                    $roadTypesDiv.append(
+                    const $radioButtonContainer = $('<div>', { class: 'csRadioButtonContainer' });
+                    $radioButtonContainer.append(
                         // TODO css
-                        createSettingsCheckbox(
-                            `csClearNew${roadTypeAbbr}CheckBox`,
+                        createSettingsRadioButton(
+                            `csClearNew${roadTypeAbbr}RadioButton`,
                             `setNew${roadTypeAbbr}StreetToNone`,
                             trans.prefs.setStreetCityToNone,
                             trans.prefs.setStreetCityToNone_Title,
                             { paddingLeft: '20px', marginRight: '4px' },
-                            { fontStyle: 'italic' }
+                            { fontStyle: 'italic' },
+                            `cs${roadTypeAbbr}SettingGroup`
                         ),
-                        createSettingsCheckbox(
-                            `csSetNew${roadTypeAbbr}CityCheckBox`,
+                        createSettingsRadioButton(
+                            `csSetNew${roadTypeAbbr}CityRadioButton`,
                             `setNew${roadTypeAbbr}City`,
                             trans.prefs.setCityToConnectedSegCity,
                             '',
-                            { paddingLeft: '30px', marginRight: '4px' },
-                            { fontStyle: 'italic' }
+                            { paddingLeft: '20px', marginRight: '4px' },
+                            { fontStyle: 'italic' },
+                            `cs${roadTypeAbbr}SettingGroup`
                         )
                     );
+                    $roadTypeContainer.append($radioButtonContainer);
                 }
             });
 
@@ -967,9 +987,16 @@
                 }
                 saveSettingsToStorage();
             });
-            $('.csSettingsCheckBox').change(function onSettingsCheckChanged() {
+            $('.csSettingsControl').change(function onSettingsCheckChanged() {
                 const { checked } = this;
                 const settingName = $(this).data('setting-name');
+
+                if (!checked) {
+                    $(this).siblings('.csRadioButtonContainer').hide();
+                } else {
+                    $(this).siblings('.csRadioButtonContainer').show();
+                }
+
                 if (settingName === 'roadType') {
                     const roadType = $(this).data('road-type');
                     const array = _settings.roadTypeButtons;
@@ -980,7 +1007,18 @@
                         array.splice(index, 1);
                     }
                 } else {
-                    _settings[settingName] = checked;
+                    const roadTypeAbbr = $(this).parent().parent().siblings().attr('data-road-type');
+                    if (settingName.includes('setNew')) {
+                        _settings[settingName] = checked;
+
+                        if (settingName.endsWith('StreetToNone')) {
+                            _settings[`setNew${roadTypeAbbr}City`] = !checked;
+                        } else {
+                            _settings[`setNew${roadTypeAbbr}StreetToNone`] = !checked;
+                        }
+                    } else {
+                        _settings[settingName] = checked;
+                    }
                 }
                 saveSettingsToStorage();
             });

--- a/WME ClickSaver.js
+++ b/WME ClickSaver.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name            WME ClickSaver
 // @namespace       https://greasyfork.org/users/45389
-// @version         2025.03.14.002
+// @version         2025.03.28.001
 // @description     Various UI changes to make editing faster and easier.
 // @author          MapOMatic
 // @include         /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/
@@ -24,7 +24,7 @@
 (function main() {
     'use strict';
 
-    const updateMessage = 'New: Option to hide road type buttons in Compact mode (thanks to LihtsaltMats!)';
+    const updateMessage = '<b>New</b><br>• Changed "Set street/city to..." script options from checkboxes to simpler dropdowns (thanks to LihtsaltMats!)<br><br>NOTE: you will need to set these options again.<br><br>';
     const scriptName = GM_info.script.name;
     const scriptVersion = GM_info.script.version;
     const downloadUrl = 'https://greasyfork.org/scripts/369629-wme-clicksaver/code/WME%20ClickSaver.user.js';


### PR DESCRIPTION
https://github.com/WazeDev/WME-ClickSaver/issues/47

Replaces the multiple choice checkboxes with radio buttons 
![image](https://github.com/user-attachments/assets/668edfac-a500-4a45-8ad8-b65d6923eee9)

It will hide the road type radio buttons if the main checkbox is unchecked so that we'd use the same style as with "Add road type buttons". 

For (hopefully) seamless migration I changed the order of the settings so if someone had both checkboxes checked it will read the city name setting last and it will be ticked. 