### PR TITLE
Check if the segments have any house numbers before removing the stre…

### DIFF
--- a/WME ClickSaver.js
+++ b/WME ClickSaver.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name            WME ClickSaver
 // @namespace       https://greasyfork.org/users/45389
-// @version         2025.04.13.001
+// @version         2025.05.01.000
 // @description     Various UI changes to make editing faster and easier.
 // @author          MapOMatic
 // @include         /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/


### PR DESCRIPTION
Native UI doesn't allow us to remove the street name when a selected segment has a house number. This will disable the button and add a (hopefully) useful tooltip. 
House numbers on segments with a street name but without a city name are allowed. 